### PR TITLE
피드 조회시 좋아요 우선 정렬

### DIFF
--- a/src/main/java/sisibibi/wanttogram/feed/controller/FeedController.java
+++ b/src/main/java/sisibibi/wanttogram/feed/controller/FeedController.java
@@ -44,13 +44,11 @@ public class FeedController {
 	@GetMapping // 피드 페이징 조회
 	public ResponseEntity<Page<FeedResponseDto>> findAllFeed(
 		@PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable,
-		@RequestParam(required = false) String startDate,
-		@RequestParam(required = false) String endDate) {
+		@RequestParam(required = false, defaultValue = "1990-01-01") String startDate,
+		@RequestParam(required = false, defaultValue = "2099-12-31") String endDate) {
 
-		LocalDateTime start = startDate == null ?
-			LocalDateTime.MIN : LocalDate.parse(startDate).atStartOfDay();
-		LocalDateTime end = endDate == null ?
-			LocalDateTime.MAX : LocalDate.parse(endDate).atTime(23, 59, 59);
+		LocalDateTime start = LocalDate.parse(startDate).atStartOfDay();
+		LocalDateTime end = LocalDate.parse(endDate).atTime(23, 59, 59);
 
 		Page<FeedResponseDto> feeds = feedService.findAllFeed(start, end, pageable)
 			.map(feedEntity ->
@@ -64,7 +62,7 @@ public class FeedController {
 				)
 			);
 
-		return new ResponseEntity<>(feeds, HttpStatus.OK);
+		return ResponseEntity.ok(feeds);
 	}
 
 	// 피드 단일 조회

--- a/src/main/java/sisibibi/wanttogram/feed/controller/FeedController.java
+++ b/src/main/java/sisibibi/wanttogram/feed/controller/FeedController.java
@@ -1,5 +1,7 @@
 package sisibibi.wanttogram.feed.controller;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,61 +9,87 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import sisibibi.wanttogram.feed.domain.FeedResponseDto;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import sisibibi.wanttogram.feed.domain.FeedRequestDto;
+import sisibibi.wanttogram.feed.domain.FeedResponseDto;
 import sisibibi.wanttogram.feed.entity.FeedEntity;
 import sisibibi.wanttogram.feed.service.FeedService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/feeds")
 @RequiredArgsConstructor
 public class FeedController {
 
-    private final FeedService feedService;
+	private final FeedService feedService;
 
-    @PostMapping // 피드 생성
-    public ResponseEntity<FeedResponseDto> createFeed(@RequestBody FeedRequestDto request) {
+	@PostMapping // 피드 생성
+	public ResponseEntity<FeedResponseDto> createFeed(@RequestBody FeedRequestDto request) {
 
-        FeedEntity feed = feedService.createFeed(request);
-        FeedResponseDto feedResponseDto = new FeedResponseDto(feed.getId(), feed.getWriter().getName(),
-                feed.getTitle(), feed.getContent(), feed.getCreatedAt(), feed.getUpdatedAt());
+		FeedEntity feed = feedService.createFeed(request);
+		FeedResponseDto feedResponseDto = new FeedResponseDto(feed.getId(),
+			feed.getWriter().getName(),
+			feed.getTitle(), feed.getContent(), feed.getCreatedAt(), feed.getUpdatedAt());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(feedResponseDto);
-    }
+		return ResponseEntity.status(HttpStatus.CREATED).body(feedResponseDto);
+	}
 
-    @GetMapping // 피드 페이징 조회
-    public ResponseEntity<Page<FeedResponseDto>> findAllFeed(
-            @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable,
-            @RequestParam(required = false) String startDate,
-            @RequestParam(required = false) String endDate) {
-        Page<FeedResponseDto> feedResponseDtosList = feedService.findAllFeed(startDate, endDate, pageable);
-        return new ResponseEntity<>(feedResponseDtosList, HttpStatus.OK);
-    }
+	@GetMapping // 피드 페이징 조회
+	public ResponseEntity<Page<FeedResponseDto>> findAllFeed(
+		@PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable,
+		@RequestParam(required = false) String startDate,
+		@RequestParam(required = false) String endDate) {
 
-    // 피드 단일 조회
-    @GetMapping("/{id}")
-    public ResponseEntity<FeedResponseDto> findFeedById(@PathVariable Long id) {
-        FeedResponseDto feedResponseDto = feedService.findFeedById(id);
-        return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
-    }
+		LocalDateTime start = startDate == null ?
+			LocalDateTime.MIN : LocalDate.parse(startDate).atStartOfDay();
+		LocalDateTime end = endDate == null ?
+			LocalDateTime.MAX : LocalDate.parse(endDate).atTime(23, 59, 59);
 
-    // 피드 수정
-    @PutMapping("/{id}")
-    public ResponseEntity<FeedResponseDto> updateFeed(@PathVariable Long id, @RequestBody FeedRequestDto request) {
-        FeedEntity feed = feedService.updateFeed(id, request);
-        FeedResponseDto feedResponseDto = new FeedResponseDto(feed.getId(), feed.getWriter().getName(),
-                feed.getTitle(), feed.getContent(), feed.getCreatedAt(), feed.getUpdatedAt());
+		Page<FeedResponseDto> feeds = feedService.findAllFeed(start, end, pageable)
+			.map(feedEntity ->
+				new FeedResponseDto(
+					feedEntity.getId(),
+					feedEntity.getWriter().getName(),
+					feedEntity.getTitle(),
+					feedEntity.getContent(),
+					feedEntity.getCreatedAt(),
+					feedEntity.getUpdatedAt()
+				)
+			);
 
-        return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
-    }
+		return new ResponseEntity<>(feeds, HttpStatus.OK);
+	}
 
-    // 피드 삭제
-    @DeleteMapping("/{id}") // 피드 삭제
-    public ResponseEntity<FeedResponseDto> deleteFeed(@PathVariable Long id) {
-        feedService.deleteFeed(id);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    }
+	// 피드 단일 조회
+	@GetMapping("/{id}")
+	public ResponseEntity<FeedResponseDto> findFeedById(@PathVariable Long id) {
+		FeedResponseDto feedResponseDto = feedService.findFeedById(id);
+		return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
+	}
+
+	// 피드 수정
+	@PutMapping("/{id}")
+	public ResponseEntity<FeedResponseDto> updateFeed(@PathVariable Long id,
+		@RequestBody FeedRequestDto request) {
+		FeedEntity feed = feedService.updateFeed(id, request);
+		FeedResponseDto feedResponseDto = new FeedResponseDto(feed.getId(),
+			feed.getWriter().getName(),
+			feed.getTitle(), feed.getContent(), feed.getCreatedAt(), feed.getUpdatedAt());
+
+		return new ResponseEntity<>(feedResponseDto, HttpStatus.OK);
+	}
+
+	// 피드 삭제
+	@DeleteMapping("/{id}") // 피드 삭제
+	public ResponseEntity<FeedResponseDto> deleteFeed(@PathVariable Long id) {
+		feedService.deleteFeed(id);
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
 }

--- a/src/main/java/sisibibi/wanttogram/feed/repository/FeedRepository.java
+++ b/src/main/java/sisibibi/wanttogram/feed/repository/FeedRepository.java
@@ -1,5 +1,6 @@
 package sisibibi.wanttogram.feed.repository;
 
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,19 +10,26 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import sisibibi.wanttogram.feed.entity.FeedEntity;
 
-import java.time.LocalDateTime;
-
 public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
 
-    default FeedEntity findFeedByIdOrElseThrowById(Long id) {
-        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Feed not found"));
-    }
+	default FeedEntity findFeedByIdOrElseThrowById(Long id) {
+		return findById(id).orElseThrow(
+			() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Feed not found"));
+	}
 
-    Page<FeedEntity> findAllByUpdatedAtBetween(LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+	Page<FeedEntity> findAllByUpdatedAtBetween(LocalDateTime startDate, LocalDateTime endDate,
+		Pageable pageable);
 
-    @Query("SELECT f FROM FeedEntity f WHERE f.writer.id IN (SELECT fl.following.id FROM FollowEntity fl WHERE fl.follower.id = :userId) " +
-            "OR f.writer.id = :userId")
-    Page<FeedEntity> findAllFeedsByFollowing(@Param("userId") Long userId, Pageable pageable);
+	@Query("""
+		SELECT f
+		FROM FeedEntity f
+		WHERE f.writer.id IN (
+		  SELECT fl.following.id
+		  FROM FollowEntity fl
+		  WHERE fl.follower.id = :userId)
+		OR f.writer.id = :userId
+		""")
+	Page<FeedEntity> findAllFeedsByFollowing(@Param("userId") Long userId, Pageable pageable);
 
 
 }

--- a/src/main/java/sisibibi/wanttogram/feed/service/FeedService.java
+++ b/src/main/java/sisibibi/wanttogram/feed/service/FeedService.java
@@ -2,91 +2,71 @@ package sisibibi.wanttogram.feed.service;
 
 
 import jakarta.servlet.http.HttpSession;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import sisibibi.wanttogram.feed.domain.FeedResponseDto;
 import sisibibi.wanttogram.feed.domain.FeedRequestDto;
+import sisibibi.wanttogram.feed.domain.FeedResponseDto;
 import sisibibi.wanttogram.feed.entity.FeedEntity;
 import sisibibi.wanttogram.feed.repository.FeedRepository;
 import sisibibi.wanttogram.member.entity.MemberEntity;
 import sisibibi.wanttogram.member.infrastructure.MemberRepository;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional
 @RequiredArgsConstructor
 @Service
 public class FeedService {
 
-    private final FeedRepository feedRepository;
-    private final HttpSession session;
-    private final MemberRepository memberRepository;
+	private final FeedRepository feedRepository;
+	private final HttpSession session;
+	private final MemberRepository memberRepository;
 
 
-    public FeedEntity createFeed(FeedRequestDto request) {
-        MemberEntity member = memberRepository.findByEmail((String) session.getAttribute("userEmail"))
-                .orElseThrow(() -> new RuntimeException("User not found"));
-        FeedEntity feed = new FeedEntity(null, member, request.getTitle(), request.getContent(), null, null);
-        return feedRepository.save(feed);
+	public FeedEntity createFeed(FeedRequestDto request) {
+		MemberEntity member = memberRepository.findByEmail(
+				(String) session.getAttribute("userEmail"))
+			.orElseThrow(() -> new RuntimeException("User not found"));
+		FeedEntity feed = new FeedEntity(null, member, request.getTitle(), request.getContent(),
+			null, null);
+		return feedRepository.save(feed);
 
-    }
+	}
 
-    // 피드 페이징 조회
-    @Transactional(readOnly = true)
-    public Page<FeedResponseDto> findAllFeed(String startDate, String endDate, Pageable pageable) {
-        LocalDateTime start = (startDate == null) ? LocalDateTime.MIN : LocalDate.parse(startDate).atStartOfDay();
-        LocalDateTime end = (endDate == null) ? LocalDateTime.MAX : LocalDate.parse(endDate).atTime(23, 59, 59);
+	// 피드 페이징 조회
+	@Transactional(readOnly = true)
+	public Page<FeedEntity> findAllFeed(LocalDateTime start, LocalDateTime end, Pageable pageable) {
+		MemberEntity member = memberRepository.findByEmail(
+			(String) session.getAttribute("userEmail")).orElse(null);
 
-        Page<FeedEntity> feedList = null;
-        MemberEntity member = memberRepository.findByEmail((String) session.getAttribute("userEmail"))
-                .orElse(null);
+		return member == null ?
+			feedRepository.findAllByUpdatedAtBetween(start, end, pageable)
+			: feedRepository.findAllFeedsByFollowing(member.getId(), pageable);
+	}
 
-        if (member!= null) {
-            feedList = feedRepository.findAllFeedsByFollowing(member.getId(), pageable);
-            System.out.println(feedList.stream().count());
-        } else {
-            feedList = feedRepository.findAllByUpdatedAtBetween(start, end, pageable);
-
-        }
-
-        Page<FeedResponseDto> dtoList = feedList
-                .map(feedEntity -> new FeedResponseDto(feedEntity.getId(), feedEntity.getWriter().getName(),
-                        feedEntity.getTitle(), feedEntity.getContent(), feedEntity.getCreatedAt(),
-                        feedEntity.getUpdatedAt()));
-        return dtoList;
-    }
-
-    // 피드 단일 조회
-    public FeedResponseDto findFeedById(Long id) {
-        FeedEntity feed = feedRepository.findFeedByIdOrElseThrowById(id);
-        return new FeedResponseDto(feed.getId(), feed.getWriter().getName(), feed.getTitle(), feed.getContent(),
-                feed.getCreatedAt(), feed.getUpdatedAt());
-    }
+	// 피드 단일 조회
+	public FeedResponseDto findFeedById(Long id) {
+		FeedEntity feed = feedRepository.findFeedByIdOrElseThrowById(id);
+		return new FeedResponseDto(feed.getId(), feed.getWriter().getName(), feed.getTitle(),
+			feed.getContent(),
+			feed.getCreatedAt(), feed.getUpdatedAt());
+	}
 
 
-    // 피드 업데이트
-    public FeedEntity updateFeed(Long id, FeedRequestDto request) {
-        FeedEntity feed = feedRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Feed not found"));
-        feed.updateFeedDto(request);
-        return feed;
-    }
+	// 피드 업데이트
+	public FeedEntity updateFeed(Long id, FeedRequestDto request) {
+		FeedEntity feed = feedRepository.findById(id)
+			.orElseThrow(() -> new RuntimeException("Feed not found"));
+		feed.updateFeedDto(request);
+		return feed;
+	}
 
-    // 피드 삭제
-    public void deleteFeed(Long id) {
-        feedRepository.deleteById(id);
-    }
+	// 피드 삭제
+	public void deleteFeed(Long id) {
+		feedRepository.deleteById(id);
+	}
 }
 
 


### PR DESCRIPTION
## 구현사항
- [x] Feed 조회시 좋아요를 우선으로 정렬하도록 설정
- [x] startDate, endDate에 Min, Max가 아닌 기본값 설정되도록 변경

## 트러블 슈팅

피드에 값을 넣어두고 조회를 해보니 아무런 값도 응답이 오지 않아서 아래처럼 확인해보았습니다.

<img width="1075" alt="스크린샷 2024-12-26 오전 11 56 43" src="https://github.com/user-attachments/assets/4813be93-6136-44a4-9631-afaf009d85a2" />

feeds의 total이 0이네요.
그리고, start와 end에 각각 "-999999999-01-01T00:00", "+999999999-12-31T23:59:59.999999999"이 들어가 있습니다.

데이터 베이스가 인식하는 최소 최대와 Java가 인식하는 최소 최대가 달라서 데이터를 불러오지 못했습니다.

아래는 변경된 결과입니다.

<img width="1736" alt="스크린샷 2024-12-26 오후 1 29 27" src="https://github.com/user-attachments/assets/50f2eb35-39e9-47f8-81c0-f5dd3fc59ea3" />

(왼쪽이 전, 오른쪽이 후)

